### PR TITLE
PREAPPS-502: Increase mobile-toolbar-height by 1px to make room for border.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
 	"name": "@zimbra/x-ui",
-	"version": "1.0.0",
+	"version": "1.0.2",
 	"lockfileVersion": 1
 }

--- a/variables.less
+++ b/variables.less
@@ -2,7 +2,7 @@
 
 @toolbar-height: 49px;
 @checkbox-size: 42px;
-@mobile-toolbar-height: 56px;
+@mobile-toolbar-height: 57px;
 @external-header-height: 24px;
 @search-header-height: 72px;
 @sidebar-width: 192px;


### PR DESCRIPTION
Pretty much the same as https://github.com/Zimbra/zm-x-ui/commit/bd21cda8e63799d59f1f4e98bf576bc8429a5ed5, but for mobile.